### PR TITLE
feat: implemented setting a default address

### DIFF
--- a/eCommerce/src/pages/registerPage/index.tsx
+++ b/eCommerce/src/pages/registerPage/index.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { login } from '../../api/login';
 import { getEmailToken } from '../../api/emailToken';
 import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '../../types';
+import { INewCustomer, RootState } from '../../types';
 import { validateDob, validateEmail, validateField, validatePassword, validatePostalCode } from './validations';
 import { getCookie } from '../../api/cookie';
 
@@ -59,7 +59,7 @@ export const RegisterPage = () => {
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     try {
-      const response = await registration({
+      const newCustomer: INewCustomer = {
         email: states.email,
         password: states.password,
         firstName: states.name,
@@ -73,11 +73,14 @@ export const RegisterPage = () => {
             country: states.country,
           },
         ],
-      });
+      };
+      if (states.asDefaultShipping) newCustomer.defaultShippingAddress = 0;
+      const response = await registration(newCustomer);
       changeState('setModalTitle', 'Registration Successful!');
       changeState('setModalMessage', 'Customer successfully created');
       changeState('setShowSuccessModal', true);
       changeState('setRegistration', true);
+      changeState('setDefaultShippingAddress', false);
       console.log(response.customer);
     } catch (e: any) {
       changeState('setModalTitle', 'Registration failed!');
@@ -181,6 +184,7 @@ export const RegisterPage = () => {
             {states.dobError}
           </ErrorMsg>
         </TwoInRow>
+        <h2>Shipping address</h2>
         <TwoInRow>
           <ErrorMsg>
             <Input
@@ -234,6 +238,16 @@ export const RegisterPage = () => {
             ))}
           </Select>
         </TwoInRow>
+        <Label>
+          <Input
+            type="checkbox"
+            checked={states.asDefaultShipping}
+            onChange={() => {
+              changeState('setDefaultShippingAddress', !states.asDefaultShipping);
+            }}
+          />
+          Set as default Shipping address
+        </Label>
         <Button type="submit" text="Create account" disabled={!isFormValid()} />
       </FormField>
     </div>

--- a/eCommerce/src/pages/registerPage/style.tsx
+++ b/eCommerce/src/pages/registerPage/style.tsx
@@ -14,6 +14,10 @@ export const FormField = styled.form`
   button {
     margin-top: 1rem;
   }
+  h2 {
+    margin-top: 1rem;
+    font-size: 1.5rem;
+  }
 `;
 
 export const TwoInRow = styled.div`
@@ -48,4 +52,5 @@ export const Label = styled.label`
   column-gap: 0.5rem;
   user-select: none;
   cursor: pointer;
+  margin-top: 0.5rem;
 `;

--- a/eCommerce/src/reducers/registerReducer.ts
+++ b/eCommerce/src/reducers/registerReducer.ts
@@ -21,6 +21,7 @@ const initialState = {
   showSuccessModal: false,
   modalTitle: '',
   modalMessage: '',
+  asDefaultShipping: false,
 };
 
 const registerReducer = (
@@ -72,6 +73,8 @@ const registerReducer = (
       return { ...state, modalMessage: action.payload };
     case 'setRegistration':
       return { ...state, successfulRegistration: action.payload };
+    case 'setDefaultShippingAddress':
+      return { ...state, asDefaultShipping: action.payload };
     default:
       return state;
   }

--- a/eCommerce/src/types/index.ts
+++ b/eCommerce/src/types/index.ts
@@ -10,7 +10,7 @@ export type INewCustomer = {
   lastName: string;
   dateOfBirth: string;
   addresses: IDraftAddress[];
-  // defaultShippingAddress?: number;
+  defaultShippingAddress?: number;
   // defaultBillingAddress?: number;
   // shippingAddresses: number[];
   // billingAddresses: number[];
@@ -22,7 +22,6 @@ export type IDraftAddress = {
   postalCode: string;
   country: string;
 };
-
 
 // store
 export interface RootState {
@@ -64,4 +63,5 @@ interface IRegisterState {
   modalTitle: string;
   modalMessage: string;
   successfulRegistration: boolean;
+  asDefaultShipping: boolean;
 }


### PR DESCRIPTION
## PR Details

### Description
When users enter their address information during registration, provide an option to save the address as their default address. This default address can be used for future transactions involving shipping or billing. 📦💼

Types of changes
  - [ ] Docs change / refactoring / dependency upgrade
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
